### PR TITLE
Finish the update to crossterm 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ name = "qr2term"
 path = "src/lib.rs"
 
 [dependencies]
-crossterm = { version = "0.14", default-features = false, features = ["style"] }
+crossterm = { version = "0.14", default-features = false }
 qrcode = { version = "0.11", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ name = "qr2term"
 path = "src/lib.rs"
 
 [dependencies]
-crossterm = { version = "0.13", default-features = false, features = ["style"] }
+crossterm = { version = "0.14", default-features = false, features = ["style"] }
 qrcode = { version = "0.11", default-features = false }


### PR DESCRIPTION
Dependabot's #12 is incomplete because of the feature changes. Most functionality of `crossterm` is now always included, including the former `style` feature.